### PR TITLE
Added a simple cli for go file generation

### DIFF
--- a/cmd/gossage/main.go
+++ b/cmd/gossage/main.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/shawntoffel/gossage/internal/cli"
+)
+
+func main() {
+	migrationName := ""
+
+	if len(os.Args) > 1 {
+		migrationName = os.Args[1]
+	}
+
+	err := cli.GenerateMigrationFile(migrationName)
+	if err != nil {
+		fmt.Errorf("could not generate migration file: %s", err)
+	}
+}

--- a/cmd/gossage/main.go
+++ b/cmd/gossage/main.go
@@ -16,6 +16,6 @@ func main() {
 
 	err := cli.GenerateMigrationFile(migrationName)
 	if err != nil {
-		fmt.Errorf("could not generate migration file: %s", err)
+		fmt.Printf("gossage: could not generate migration file: %s", err)
 	}
 }

--- a/internal/cli/generate.go
+++ b/internal/cli/generate.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"html/template"
+	"os"
+	"strings"
+	"time"
+)
+
+type migration struct {
+	Name      string
+	Timestamp string
+}
+
+// Generates a migration go file via template. Expects a snake_case name.
+func GenerateMigrationFile(name string) error {
+	t, err := template.New("generate").Parse(migrationTemplate)
+	if err != nil {
+		return err
+	}
+
+	m := migration{
+		Name:      toCamelCase(name),
+		Timestamp: time.Now().Format("20060102150405"),
+	}
+
+	file, err := os.Create(m.Timestamp + "_" + name + ".go")
+	if err != nil {
+		return err
+	}
+
+	defer file.Close()
+
+	err = t.Execute(file, m)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func toCamelCase(name string) string {
+	camelCase := ""
+	capitalizeNextChar := true
+
+	for _, char := range name {
+		c := string(char)
+
+		if capitalizeNextChar {
+			c = strings.ToUpper(c)
+		}
+
+		if c == "_" {
+			capitalizeNextChar = true
+		} else {
+			capitalizeNextChar = false
+			camelCase += c
+		}
+	}
+
+	return camelCase
+}
+
+const migrationTemplate = `package migrations
+
+import "database/sql"
+
+type {{.Name}}{{.Timestamp}} struct{}
+
+func (m {{.Name}}{{.Timestamp}}) Version() string {
+	return "{{.Timestamp}}_{{.Name}}"
+}
+
+func (m {{.Name}}{{.Timestamp}}) Up(tx *sql.Tx) error {
+	_, err := tx.Exec(` + "``" + `)
+	return err
+}
+
+func (m {{.Name}}{{.Timestamp}}) Down(tx *sql.Tx) error {
+	_, err := tx.Exec(` + "``" + `)
+	return err
+}`


### PR DESCRIPTION
Usage:

`gossage create_table_foo`

Generates a timestamped go file `20190423034904_create_table_foo.go` containing the struct required for a gossage migration. 

```
 package migrations                                                               
                                                                                  
 import "database/sql"                                                            
                                                                                  
 type CreateTableFoo20190423034904 struct{}                                       
                                                                                  
 func (m CreateTableFoo20190423034904) Version() string {                         
     return "20190423034904_CreateTableFoo"                                       
 }                                                                                
                                                                                  
 func (m CreateTableFoo20190423034904) Up(tx *sql.Tx) error {                     
     _, err := tx.Exec(``)                                                        
     return err                                                                   
 }                                                                                
                                                                                  
 func (m CreateTableFoo20190423034904) Down(tx *sql.Tx) error {                   
     _, err := tx.Exec(``)                                                        
     return err                                                                   
 }
```